### PR TITLE
Use Accept header to specify response format

### DIFF
--- a/src/capturer/capturer.js
+++ b/src/capturer/capturer.js
@@ -150,7 +150,8 @@
         isFilenameTaken = async (path) => {
           const target = prefix + scrapbook.escapeFilename(path);
           const info = await server.request({
-            url: target + '?f=json',
+            url: target,
+            format: 'json',
             method: "GET",
           }).then(r => r.json()).then(r => r.data);
           return info.type !== null;
@@ -659,16 +660,18 @@
         const target = book.treeUrl + 'favicon/' + file.name;
 
         const json = await server.request({
-          url: target + '?f=json',
+          url: target,
           method: "GET",
+          format: 'json',
         }).then(r => r.json());
 
         // save favicon if nonexistent or emptied
         if (json.data.type === null || 
             (file.size > 0 && json.data.type === 'file' && json.data.size === 0)) {
           await server.request({
-            url: target + '?a=save&f=json',
+            url: target + '?a=save',
             method: "POST",
+            format: 'json',
             csrfToken: true,
             body: {
               upload: file,
@@ -1561,8 +1564,9 @@ Redirecting to file <a href="${scrapbook.escapeHtml(response.url)}">${scrapbook.
           
           const blob = new Blob([content], {type: "text/html"});
           await server.request({
-            url: target + '?a=save&f=json',
+            url: target + '?a=save',
             method: "POST",
+            format: 'json',
             csrfToken: true,
             body: {
               upload: blob,
@@ -1585,8 +1589,9 @@ Redirecting to file <a href="${scrapbook.escapeHtml(response.url)}">${scrapbook.
         if (!file) { continue; }
         const target = internalizePrefix + file.name;
         await server.request({
-          url: target + '?a=save&f=json',
+          url: target + '?a=save',
           method: "POST",
+          format: 'json',
           csrfToken: true,
           body: {
             upload: file,
@@ -2808,8 +2813,9 @@ Redirecting to <a href="${scrapbook.escapeHtml(target)}">${scrapbook.escapeHtml(
       while (true) {
         try {
           await server.request({
-            url: target + '?a=save&f=json',
+            url: target + '?a=save',
             method: "POST",
+            format: 'json',
             csrfToken: true,
             body: {
               upload: blob,

--- a/src/indexer/load.js
+++ b/src/indexer/load.js
@@ -456,6 +456,7 @@ svg, math`;
 
         const loadEntry = async (book, inputData) => {
           const target = book.topUrl;
+          // TODO drop "f=sse" since new backend obtains format from Accept header
           const evtSource = new EventSource(target + '?a=list&f=sse&recursive=1');
 
           return await new Promise((resolve, reject) => {
@@ -1973,8 +1974,9 @@ svg, math`;
           try {
             const target = book.topUrl + scrapbook.escapeFilename(this.treeBakDir);
             await server.request({
-              url: target + '?a=delete&f=json',
+              url: target + '?a=delete',
               method: 'POST',
+              format: 'json',
               csrfToken: true,
             });
           } catch (ex) {
@@ -1988,8 +1990,9 @@ svg, math`;
             if (inZipPath.startsWith(this.faviconDir) && zipObj.comment === "emptying") {
               const target = book.topUrl + scrapbook.escapeFilename(inZipPath);
               await server.request({
-                url: target + '?a=delete&f=json',
+                url: target + '?a=delete',
                 method: 'POST',
+                format: 'json',
                 csrfToken: true,
               });
               continue;
@@ -2002,8 +2005,9 @@ svg, math`;
             );
             const target = book.topUrl + scrapbook.escapeFilename(inZipPath);
             await server.request({
-              url: target + '?a=save&f=json',
+              url: target + '?a=save',
               method: 'POST',
+              format: 'json',
               csrfToken: true,
               body: {
                 upload: file,

--- a/src/scrapbook/edit.js
+++ b/src/scrapbook/edit.js
@@ -114,8 +114,9 @@
           // upload text content
           const content = document.getElementById("editor").value;
           await server.request({
-            url: this.target + '?a=save&f=json',
+            url: this.target + '?a=save',
             method: "POST",
+            format: 'json',
             csrfToken: true,
             body: {
               text: scrapbook.unicodeToUtf8(content),

--- a/src/scrapbook/tree.js
+++ b/src/scrapbook/tree.js
@@ -43,8 +43,9 @@
       async exec_book(selectedItemElems) {
         const target = this.book.topUrl;
         await server.request({
-          url: target + '?a=exec&f=json',
+          url: target + '?a=exec',
           method: "GET",
+          format: 'json',
         });
       },
 
@@ -111,8 +112,9 @@
           }
 
           await server.request({
-            url: target + '?a=exec&f=json',
+            url: target + '?a=exec',
             method: "GET",
+            format: 'json',
           });
         }
       },
@@ -132,8 +134,9 @@
           }
 
           await server.request({
-            url: target + '?a=browse&f=json',
+            url: target + '?a=browse',
             method: "GET",
+            format: 'json',
           });
         }
       },
@@ -384,8 +387,9 @@
 `;
               const blob = new Blob([template_text], {type: "text/html"});
               await server.request({
-                url: url + '?a=save&f=json',
+                url: url + '?a=save',
                 method: "POST",
+                format: 'json',
                 csrfToken: true,
                 body: {
                   upload: blob,
@@ -412,8 +416,9 @@
               template_text = `%NOTE_TITLE%`;
               const blob = new Blob([template_text], {type: "text/markdown"});
               await server.request({
-                url: url + '?a=save&f=json',
+                url: url + '?a=save',
                 method: "POST",
+                format: 'json',
                 csrfToken: true,
                 body: {
                   upload: blob,
@@ -446,8 +451,9 @@
 
         // save data files
         await server.request({
-          url: target + '?a=save&f=json',
+          url: target + '?a=save',
           method: "POST",
+          format: 'json',
           csrfToken: true,
           body: {
             upload: blob,
@@ -468,8 +474,9 @@ Redirecting to file <a href="index.md">index.md</a>
 </html>`;
           const blob = new Blob([content], {type: 'text/plain'});
           await server.request({
-            url: target + '?a=save&f=json',
+            url: target + '?a=save',
             method: "POST",
+            format: 'json',
             csrfToken: true,
             body: {
               upload: blob,
@@ -708,8 +715,9 @@ Redirecting to file <a href="index.md">index.md</a>
           const index = itemIndexFile.replace(/\/index.[^.]+$/, '');
           const target = this.book.dataUrl + scrapbook.escapeFilename(index);
           await server.request({
-            url: target + '?a=delete&f=json',
+            url: target + '?a=delete',
             method: "POST",
+            format: 'json',
             csrfToken: true,
           });
         };
@@ -1749,8 +1757,9 @@ Redirecting to file <a href="index.md">index.md</a>
             {
               const target = this.book.dataUrl + scrapbook.escapeFilename(newItem.id + '/' + filename);
               await server.request({
-                url: target + '?a=save&f=json',
+                url: target + '?a=save',
                 method: "POST",
+                format: 'json',
                 csrfToken: true,
                 body: {
                   upload: file,
@@ -1776,8 +1785,9 @@ Redirecting to file <a href="${scrapbook.escapeHtml(url)}">${scrapbook.escapeHtm
               const file = new File([html], 'index.html', {type: 'text/html'});
               const target = this.book.dataUrl + scrapbook.escapeFilename(newItem.id + '/index.html');
               await server.request({
-                url: target + '?a=save&f=json',
+                url: target + '?a=save',
                 method: "POST",
+                format: 'json',
                 csrfToken: true,
                 body: {
                   upload: file,


### PR DESCRIPTION
- Retain old `f=json` query parameter for backward compatibility
- Fix a typo in `server.request` iteration over headers

Add convenience arguments to `server.request()`:
- `csrfToken` to acquire token and add it to request,
- `accept` to specify response format,
- `form` to create `FormData` object and to add fields to it.

The intention is to allow authentication by an external application
that could obtain desired error format in a standard way #177.