### PR TITLE
Fix mime types in tests on linux

### DIFF
--- a/test/server.py
+++ b/test/server.py
@@ -5,6 +5,9 @@ import http.server
 from threading import Thread
 import time
 
+http.server.SimpleHTTPRequestHandler.extensions_map[".md"] = "text/markdown"
+
+
 class HTTPRequestHandler(http.server.CGIHTTPRequestHandler):
     def send_head(self):
         """Modified default CGIHTTPRequestHandler:
@@ -44,7 +47,6 @@ class HTTPRequestHandler(http.server.CGIHTTPRequestHandler):
             return True
         return False
 
-    http.server.SimpleHTTPRequestHandler.extensions_map[".md"] = "text/markdown"
 
 def main():
     # load config.json

--- a/test/server.py
+++ b/test/server.py
@@ -6,6 +6,9 @@ from threading import Thread
 import time
 
 http.server.SimpleHTTPRequestHandler.extensions_map[".md"] = "text/markdown"
+# "image/x-ms-bmp" is used on linux by default, but test asserts check for "image/bmp"
+http.server.SimpleHTTPRequestHandler.extensions_map[".bmp"] = "image/bmp"
+http.server.SimpleHTTPRequestHandler.extensions_map[".woff"] = "application/octet-stream"
 
 
 class HTTPRequestHandler(http.server.CGIHTTPRequestHandler):


### PR DESCRIPTION
Prevent test failures due to another mime types sent by the python server.