### PR TITLE
feat: set opt_server.url default value

### DIFF
--- a/src/core/options.js
+++ b/src/core/options.js
@@ -201,6 +201,13 @@
     if (elem.value === 'folder' && mode === 'file') {
       elem.querySelector(':enabled').selected = true;
     }
+    
+    if (mode === 'server') {
+      var url = document.getElementById("opt_server.url").value;
+      if (url === '') {
+        document.getElementById("opt_server.url").value = 'http://localhost:8080/';
+      }
+    }
   }
 
   function renewCaptureSaveAsDetails() {


### PR DESCRIPTION
當 `opt_capture.saveTo` 值為 `server` 時，
並且伺服器位址未設定時，
自動將伺服器位址設定成預設值 `http://localhost:8080/`