### PR TITLE
Add option to put item at the top/bottom of the folder

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -873,6 +873,21 @@
   "OptionCaptureInsertInfoBarTooltip": {
     "message": "If checked, a script will be inserted in a captured or saved page to show an infobar at page top (requires JavaScript).\n\n• NOTE: Archive page viewer cannot show the infobar as it does not support JavaScript. Use a viewing technique that supports JavaScript to work with an archive page, such as opening the index page after unzipping."
   },
+  "OptionCaptureInsertPositionBottomLabel": {
+    "message": "bottom"
+  },
+  "OptionCaptureInsertPositionPostLabel": {
+    "message": "of the folder"
+  },
+  "OptionCaptureInsertPositionPreLabel": {
+    "message": "Put item at the"
+  },
+  "OptionCaptureInsertPositionTooltip": {
+    "message": "A captured web page item can be placed either at the top or the bottom of the Table of Contents folder in the WebScrapBook sidebar."
+  },
+  "OptionCaptureInsertPositionTopLabel": {
+    "message": "top"
+  },
   "OptionCaptureLinkUnsavedUriLabel": {
     "message": "Link uncaptured resource to source"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -873,6 +873,21 @@
   "OptionCaptureInsertInfoBarTooltip": {
     "message": "勾选时会在获取或保存的页面加入脚本，使浏览器在页面顶部显示信息条（须启用 JavaScript）。\n\n• 注意：封存页面检视器由于不支援 JavaScript，无法显示信息条。若要用于封存页面，须改用支援 JavaScript 的检视方法，例如解压缩后开启。"
   },
+  "OptionCaptureInsertPositionBottomLabel": {
+    "message": "bottom"
+  },
+  "OptionCaptureInsertPositionPostLabel": {
+    "message": "of the folder"
+  },
+  "OptionCaptureInsertPositionPreLabel": {
+    "message": "Put item at the"
+  },
+  "OptionCaptureInsertPositionTooltip": {
+    "message": "A captured web page item can be placed either at the top or the bottom of the Table of Contents folder in the WebScrapBook sidebar."
+  },
+  "OptionCaptureInsertPositionTopLabel": {
+    "message": "top"
+  },
   "OptionCaptureLinkUnsavedUriLabel": {
     "message": "将无法储存的资源连往原始位址"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -873,6 +873,21 @@
   "OptionCaptureInsertInfoBarTooltip": {
     "message": "勾選時會在擷取或儲存的頁面加入腳本，使瀏覽器在頁面頂部顯示資訊條（須啟用 JavaScript）。\n\n• 注意：封存頁面檢視器由於不支援 JavaScript，無法顯示資訊條。若要用於封存頁面，須改用支援 JavaScript 的檢視方法，例如解壓縮後開啟。"
   },
+  "OptionCaptureInsertPositionBottomLabel": {
+    "message": "bottom"
+  },
+  "OptionCaptureInsertPositionPostLabel": {
+    "message": "of the folder"
+  },
+  "OptionCaptureInsertPositionPreLabel": {
+    "message": "Put item at the"
+  },
+  "OptionCaptureInsertPositionTooltip": {
+    "message": "A captured web page item can be placed either at the top or the bottom of the Table of Contents folder in the WebScrapBook sidebar."
+  },
+  "OptionCaptureInsertPositionTopLabel": {
+    "message": "top"
+  },
   "OptionCaptureLinkUnsavedUriLabel": {
     "message": "將無法儲存的資源連往原始位址"
   },

--- a/src/core/common.js
+++ b/src/core/common.js
@@ -126,6 +126,7 @@ if (Node && !Node.prototype.getRootNode) {
     "capture.deleteErasedOnSave": false,
     "capture.backupForRecapture": true,
     "capture.zipCompressLevel": null,
+    "capture.insertPosition": "Infinity",
     "autocapture.enabled": false,
     "autocapture.rules": "",
     "editor.autoInit": true,

--- a/src/core/options.html
+++ b/src/core/options.html
@@ -155,6 +155,15 @@
         <label for="opt_capture.saveDataUriAsFile">__MSG_OptionCaptureSaveDataUriAsFileLabel__</label>
         <a href="javascript:" data-tooltip="__MSG_OptionCaptureSaveDataUriAsFileTooltip__"></a>
       </fieldset>
+      <fieldset>
+        <label for="opt_capture.insertPosition">__MSG_OptionCaptureInsertPositionPreLabel__</label>
+        <select id="opt_capture.insertPosition">
+          <option value="0">__MSG_OptionCaptureInsertPositionTopLabel__</option>
+          <option value="Infinity">__MSG_OptionCaptureInsertPositionBottomLabel__</option>
+        </select>
+        <label for="opt_capture.insertPosition">__MSG_OptionCaptureInsertPositionPostLabel__</label>
+        <a href="javascript:" data-tooltip="__MSG_OptionCaptureInsertPositionTooltip__"></a>
+      </fieldset>
     </div>
   </details>
   <details id="group_capture" open>

--- a/src/scrapbook/server.js
+++ b/src/scrapbook/server.js
@@ -983,13 +983,14 @@ scrapbook.toc(${JSON.stringify(jsonData, null, 2).replace(/\u2028/g, '\\u2028').
      * @param {Object} params
      * @param {?Object} params.item - null to generate a default item. Overwrites existed id.
      * @param {?string} params.parentId - null to not add to any parent
-     * @param {?integer} params.index - null or Infinity to insert to last
+     * @param {?integer} params.index - 0 to insert at beginning,
+     *                                  null or Infinity to insert at end
      * @return {Object}
      */
     addItem({
       item,
       parentId = 'root',
-      index = Infinity,
+      index = scrapbook.getOption("capture.insertPosition")
     }) {
       if (index === null) {
         index = Infinity;


### PR DESCRIPTION
A captured web page item can be placed either at the top or the bottom
of the Table of Contents folder in the WebScrapBook sidebar.