### PR TITLE
Add deploy to Chrome and Firefox webstores Github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: "deploy"
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run build process
+        run: |
+          chmod +x "${GITHUB_WORKSPACE}/build/pack.sh"
+          "${GITHUB_WORKSPACE}/build/pack.sh"
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v0.0.0
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Added support to automatically build the `.zip` files and deploy them to the Chrome and Firefox web stores via Github Action using a Github Action we created called [bpp](https://github.com/marketplace/actions/browser-plugin-publisher) that can submit the zip to the Chrome/Firefox stores automatically for you.

The only thing you would need to create is a SUBMIT_KEYS GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "zip": "./extension.crx",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./extension.xpi",
    "extId": "123",
    "sessionid": "abcd"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me. 

Otherwise, if this doesn't seem necessary, feel free to close the PR! 